### PR TITLE
feature: 1:1 DM  ( 채팅방 나가기, 채팅방 만들기 기능 구현, 시간 포멧 변경, 채팅 공백 입력 불가)

### DIFF
--- a/final-backend/src/main/java/com/mysite/project/controller/MessageController.java
+++ b/final-backend/src/main/java/com/mysite/project/controller/MessageController.java
@@ -14,7 +14,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,6 +22,7 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.util.UriUtils;
 
 import com.mysite.project.dto.chat.ChatDto;
+import com.mysite.project.dto.chat.ChatDto2;
 import com.mysite.project.service.ChatService;
 
 import lombok.RequiredArgsConstructor;
@@ -49,6 +49,10 @@ public class MessageController {
 				template.convertAndSend("/sub/"+ chatDto.getChatroom_id(), chatDto);
 			}
 			
+			else if (chatDto.getMessage_content() == "") {
+				System.out.println("공백" + chatDto);
+				template.convertAndSend("/sub/"+ chatDto.getChatroom_id(), chatDto);
+			}
 			else {
 				System.out.println("메시지" + chatDto);
 				chatService.insertMessage(chatDto); //db 저장
@@ -90,7 +94,8 @@ public class MessageController {
 	        }
 	    } 
 		
-		@PostMapping("/file-download")
+		// 파일 다운로드
+		@PostMapping("/file-download") 
 		public ResponseEntity<UrlResource> download(@RequestParam("fileName") String filename) throws MalformedURLException {
 		    // 파일 경로
 		    String filePath = "C:\\Project\\upload\\" + filename;
@@ -108,6 +113,24 @@ public class MessageController {
 		    return ResponseEntity.ok()
 		            .header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition)
 		            .body(resource);
+		}
+		
+		// 채팅방 만들기 + 해당 채팅방 번호 반환
+		@PostMapping("/createChatroom") 
+		public int createChatroom(@RequestBody ChatDto2 chatDto2) throws Exception{
+			if (chatService.searchRoom(chatDto2)== -1) { // 채팅방이 없다면 
+				chatService.voidRoom(); // 빈 채팅방을 하나 만들고
+				chatService.joinRoom1(chatDto2);//그 채팅방 번호에 join 시킴
+				chatService.joinRoom2(chatDto2);//그 채팅방 번호에 join 시킴
+			}
+			return chatService.searchRoom(chatDto2); // 채팅방 번호 반환 
+		}
+		
+		// 채팅방 나가기
+		@PostMapping("/quitChatroom")
+		public int quitRoom(@RequestBody ChatDto chatDto) throws Exception {
+			chatService.quitRoom1(chatDto); //chat_join 의 아이디 값 변경
+			return chatService.quitRoom2(chatDto); //message_db 의 아이디 값 변경
 		}
 		
 }

--- a/final-backend/src/main/java/com/mysite/project/controller/MessageController.java
+++ b/final-backend/src/main/java/com/mysite/project/controller/MessageController.java
@@ -23,6 +23,7 @@ import org.springframework.web.util.UriUtils;
 
 import com.mysite.project.dto.chat.ChatDto;
 import com.mysite.project.dto.chat.ChatDto2;
+import com.mysite.project.dto.chat.ChatDto3;
 import com.mysite.project.service.ChatService;
 
 import lombok.RequiredArgsConstructor;
@@ -133,4 +134,15 @@ public class MessageController {
 			return chatService.quitRoom2(chatDto); //message_db 의 아이디 값 변경
 		}
 		
+		//협업중인지 확인하기
+		@PostMapping("/getworkstate")
+		public List<ChatDto3> getworkState(@RequestBody ChatDto2 chatDto2) throws Exception {
+			if(chatService.getworkState(chatDto2).isEmpty()) {
+				String tmp = chatDto2.getMy_user_id();
+				chatDto2.setMy_user_id(chatDto2.getYour_user_id());
+				chatDto2.setYour_user_id(tmp);
+			}
+			
+			return chatService.getworkState(chatDto2);
+		}
 }

--- a/final-backend/src/main/java/com/mysite/project/dto/chat/ChatDto.java
+++ b/final-backend/src/main/java/com/mysite/project/dto/chat/ChatDto.java
@@ -1,6 +1,6 @@
 package com.mysite.project.dto.chat;
 
-import java.sql.Date;
+import java.sql.Timestamp;
 
 import lombok.Data;
 
@@ -10,7 +10,7 @@ public class ChatDto {
 	private int chatroom_id;
 	private String user_id;
 	private String message_content;
-	private Date message_date;	
+	private Timestamp message_date;	
 	private String img_code; // 이미지 송수신 시 String 으로 받음
 	private String file_code; // 이미지 송수신 시 String 으로 받음
 }

--- a/final-backend/src/main/java/com/mysite/project/dto/chat/ChatDto2.java
+++ b/final-backend/src/main/java/com/mysite/project/dto/chat/ChatDto2.java
@@ -1,0 +1,9 @@
+package com.mysite.project.dto.chat;
+
+import lombok.Data;
+
+@Data
+public class ChatDto2 { // 채팅방 생성을 위한 dto
+		private String my_user_id;
+		private String your_user_id;
+}

--- a/final-backend/src/main/java/com/mysite/project/dto/chat/ChatDto3.java
+++ b/final-backend/src/main/java/com/mysite/project/dto/chat/ChatDto3.java
@@ -1,0 +1,8 @@
+package com.mysite.project.dto.chat;
+
+import lombok.Data;
+
+@Data
+public class ChatDto3 {
+	String pj_status;
+}

--- a/final-backend/src/main/java/com/mysite/project/impl/ChatServiceImpl.java
+++ b/final-backend/src/main/java/com/mysite/project/impl/ChatServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.mysite.project.dto.chat.ChatDto;
+import com.mysite.project.dto.chat.ChatDto2;
 import com.mysite.project.mapper.ChatMapper;
 import com.mysite.project.service.ChatService;
 
@@ -30,5 +31,38 @@ public class ChatServiceImpl implements ChatService {
 	@Override
 	public List<ChatDto> getMessage(ChatDto chatDto) throws Exception {
 		return chatMapper.getMessage(chatDto);
+	}
+	
+	@Override
+	public int searchRoom(ChatDto2 chatDto2) throws Exception {
+		if (chatMapper.searchRoom(chatDto2) == null) {
+			return -1;
+		}
+		return chatMapper.searchRoom(chatDto2);
+	}
+	
+	@Override
+	public int voidRoom() throws Exception {
+		return chatMapper.voidRoom();
+	}
+	
+	@Override
+	public int joinRoom1(ChatDto2 chatDto2) throws Exception {
+		return chatMapper.joinRoom1(chatDto2);
+	}
+	
+	@Override
+	public int joinRoom2(ChatDto2 chatDto2) throws Exception {
+		return chatMapper.joinRoom2(chatDto2);
+	}
+	
+	@Override
+	public int quitRoom1(ChatDto chatDto) throws Exception {
+		return chatMapper.quitRoom1(chatDto);
+	}
+	
+	@Override
+	public int quitRoom2(ChatDto chatDto) throws Exception {
+		return chatMapper.quitRoom2(chatDto);
 	}
 }

--- a/final-backend/src/main/java/com/mysite/project/impl/ChatServiceImpl.java
+++ b/final-backend/src/main/java/com/mysite/project/impl/ChatServiceImpl.java
@@ -7,8 +7,10 @@ import org.springframework.stereotype.Service;
 
 import com.mysite.project.dto.chat.ChatDto;
 import com.mysite.project.dto.chat.ChatDto2;
+import com.mysite.project.dto.chat.ChatDto3;
 import com.mysite.project.mapper.ChatMapper;
 import com.mysite.project.service.ChatService;
+import com.mysite.project.vo.ProjectVO;
 
 
 @Service
@@ -64,5 +66,10 @@ public class ChatServiceImpl implements ChatService {
 	@Override
 	public int quitRoom2(ChatDto chatDto) throws Exception {
 		return chatMapper.quitRoom2(chatDto);
+	}
+	
+	@Override
+	public List<ChatDto3> getworkState(ChatDto2 chatDto2) throws Exception {
+		return chatMapper.getworkState(chatDto2);
 	}
 }

--- a/final-backend/src/main/java/com/mysite/project/mapper/ChatMapper.java
+++ b/final-backend/src/main/java/com/mysite/project/mapper/ChatMapper.java
@@ -5,8 +5,10 @@ import java.util.List;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 
 import com.mysite.project.dto.chat.ChatDto;
+import com.mysite.project.dto.chat.ChatDto2;
 
 @Mapper
 public interface ChatMapper {
@@ -16,11 +18,33 @@ public interface ChatMapper {
 	public int insertMessage(ChatDto chatDto) throws Exception;
 	
 	// 로그인 세션 정보를 바탕으로 해당 사용자와 대화하는 사람들과 그 채팅방 번호들을 select, 추가로 해당 채팅방의 마지막 메시지도 select함
-	@Select ("SELECT mj.user_id, mj.chatroom_id, m.message_content FROM chatjoin_db mj INNER JOIN (SELECT chatroom_id, MAX(message_id) AS max_message_id FROM message_db GROUP BY chatroom_id) last_message ON mj.chatroom_id = last_message.chatroom_id INNER JOIN message_db m ON last_message.max_message_id = m.message_id WHERE mj.chatroom_id IN (SELECT chatroom_id FROM message_db WHERE user_id = #{user_id}) AND mj.user_id != #{user_id}")
+	@Select ("SELECT mj.user_id, mj.chatroom_id, m.message_content FROM chatjoin_db mj LEFT JOIN (SELECT chatroom_id, MAX(message_id) AS max_message_id FROM message_db GROUP BY chatroom_id) last_message ON mj.chatroom_id = last_message.chatroom_id LEFT JOIN message_db m ON last_message.max_message_id = m.message_id WHERE mj.chatroom_id IN (SELECT chatroom_id FROM chatjoin_db WHERE user_id = #{user_id}) AND mj.user_id != #{user_id}")
 	public List<ChatDto> getChatRoom_id(ChatDto chatDto) throws Exception;
 	
 	// 채팅방 누르면 해당 방 번호를 토대로 DB에서 그간 메시지 내역들을 select 
 	@Select ("SELECT * from message_db where chatroom_id=#{chatroom_id} ")
 	public List<ChatDto> getMessage(ChatDto chatDto) throws Exception;
 	
+	// user_id 두개를 넣으면 해당 아이디가 있는 채팅방의 번호를 리턴해줍니다. [create 채팅방 관련]
+	@Select ("SELECT cj1.CHATROOM_ID FROM CHATJOIN_DB cj1 INNER JOIN CHATJOIN_DB cj2 ON cj1.CHATROOM_ID = cj2.CHATROOM_ID WHERE cj1.USER_ID = #{my_user_id} AND cj2.USER_ID = #{your_user_id}")
+	public Integer searchRoom(ChatDto2 chatDto2) throws Exception;
+	
+	// 빈 채팅방을 하나 만듭니다. [create 채팅방 관련]
+	@Insert ("INSERT INTO CHATROOM_DB (CHATROOM_ID) VALUES (null)")
+	public int voidRoom() throws Exception;
+	
+	/* 빈 채팅방에 해당 유저들을 join 시킵니다. [create 채팅방 관련] */
+	@Insert ("INSERT INTO CHATJOIN_DB (CHATJOIN_ID, USER_ID, CHATROOM_ID) SELECT null, #{my_user_id} , chatroom_id FROM CHATROOM_DB WHERE chatroom_id = (SELECT MAX(chatroom_id) FROM CHATROOM_DB)")
+	public int joinRoom1(ChatDto2 chatDto2) throws Exception;
+	
+	@Insert ("INSERT INTO CHATJOIN_DB (CHATJOIN_ID, USER_ID, CHATROOM_ID) SELECT null, #{your_user_id} , chatroom_id FROM CHATROOM_DB WHERE chatroom_id = (SELECT MAX(chatroom_id) FROM CHATROOM_DB)")
+	public int joinRoom2(ChatDto2 chatDto2) throws Exception;
+	/* 빈 채팅방에 해당 유저들을 join 시킵니다. [create 채팅방 관련] */
+	
+	// 채팅방 나가기 기능 [ user_id와 chatroom_id를 가져와서 해당 user_id를 (알 수 없음) 으로 바꿈 ]
+	@Update ("UPDATE CHATJOIN_DB SET USER_ID = '(알 수 없음)' WHERE USER_ID = #{user_id} AND CHATROOM_ID = #{chatroom_id}")
+	public int quitRoom1(ChatDto chatDto) throws Exception;
+	
+	@Update ("UPDATE MESSAGE_DB SET USER_ID = '(알 수 없음)' WHERE USER_ID = #{user_id} AND CHATROOM_ID = #{chatroom_id}")
+	public int quitRoom2(ChatDto chatDto) throws Exception;
 }

--- a/final-backend/src/main/java/com/mysite/project/mapper/ChatMapper.java
+++ b/final-backend/src/main/java/com/mysite/project/mapper/ChatMapper.java
@@ -9,6 +9,8 @@ import org.apache.ibatis.annotations.Update;
 
 import com.mysite.project.dto.chat.ChatDto;
 import com.mysite.project.dto.chat.ChatDto2;
+import com.mysite.project.dto.chat.ChatDto3;
+import com.mysite.project.vo.ProjectVO;
 
 @Mapper
 public interface ChatMapper {
@@ -47,4 +49,9 @@ public interface ChatMapper {
 	
 	@Update ("UPDATE MESSAGE_DB SET USER_ID = '(알 수 없음)' WHERE USER_ID = #{user_id} AND CHATROOM_ID = #{chatroom_id}")
 	public int quitRoom2(ChatDto chatDto) throws Exception;
+	
+	// 채팅 상대와 협업중인지 알기 위한 select 문
+	@Select ("SELECT pj_status FROM pj_status_db WHERE user_id = #{my_user_id} AND pj_num IN (SELECT pj_num FROM project_db WHERE user_id = #{your_user_id})")
+	public List<ChatDto3> getworkState(ChatDto2 chatDto2) throws Exception;
+	
 }

--- a/final-backend/src/main/java/com/mysite/project/mapper/MemberMapper.java
+++ b/final-backend/src/main/java/com/mysite/project/mapper/MemberMapper.java
@@ -15,7 +15,7 @@ public interface MemberMapper {
 	@Insert("INSERT INTO user_db VALUES (#{user_id}, #{user_pw}, #{user_name}, #{user_email}, #{user_tel}, #{user_code})")
 	public int insertMember(MemberVO memberVO);
 	
-	@Select("SELECT user_id, user_name, user_email, user_tel FROM user_db WHERE user_id=#{user_id}")
+	@Select("SELECT user_id, user_name, user_email, user_tel, user_code FROM user_db WHERE user_id=#{user_id}")
 	public MemberVO findMemberInfo(@Param("user_id")String user_id);
 	//회원정보 불러오기(비밀번호 제외)
 	

--- a/final-backend/src/main/java/com/mysite/project/service/ChatService.java
+++ b/final-backend/src/main/java/com/mysite/project/service/ChatService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.mysite.project.dto.chat.ChatDto;
 import com.mysite.project.dto.chat.ChatDto2;
+import com.mysite.project.dto.chat.ChatDto3;
 
 public interface ChatService {
 	public int insertMessage(ChatDto chatDto) throws Exception;
@@ -15,4 +16,5 @@ public interface ChatService {
 	public int joinRoom2(ChatDto2 chatDto2) throws Exception;
 	public int quitRoom1(ChatDto chatDto) throws Exception;
 	public int quitRoom2(ChatDto chatDto) throws Exception;
+	public List<ChatDto3> getworkState(ChatDto2 chatDto2) throws Exception;
 }

--- a/final-backend/src/main/java/com/mysite/project/service/ChatService.java
+++ b/final-backend/src/main/java/com/mysite/project/service/ChatService.java
@@ -3,9 +3,16 @@ package com.mysite.project.service;
 import java.util.List;
 
 import com.mysite.project.dto.chat.ChatDto;
+import com.mysite.project.dto.chat.ChatDto2;
 
 public interface ChatService {
 	public int insertMessage(ChatDto chatDto) throws Exception;
 	public List<ChatDto> getChatRoom_id(ChatDto chatDto) throws Exception;
 	public List<ChatDto> getMessage(ChatDto chatDto) throws Exception;
+	public int searchRoom(ChatDto2 chatDto2) throws Exception;
+	public int voidRoom() throws Exception;
+	public int joinRoom1(ChatDto2 chatDto2) throws Exception;
+	public int joinRoom2(ChatDto2 chatDto2) throws Exception;
+	public int quitRoom1(ChatDto chatDto) throws Exception;
+	public int quitRoom2(ChatDto chatDto) throws Exception;
 }


### PR DESCRIPTION
채팅방 만들기는 해당 페이지에서는 지원을 하지 않습니다.

다른 페이지에서 (이를테면 DM 버튼을 눌렀을 시)
{
    "my_user_id" : "유저아이디1",
    "your_user_id" : "유저아이디2"
}
해당 형태로 json 전송하면 채팅방이 만들어지고  /direct 페이지로 연결시켜주시면 됩니다. 

채팅방 나가기는 남아있는 사람이 해당 채팅방에 들어갈 수 있게끔
delete가 아닌 update로 처리했습니다.
따라서 user_db에 user_id가 "(알 수 없음)" 인 더미데이터를 하나 추가해야 정상적으로 사용할 수 있습니다.

메시지 시간은 오늘 날짜가 아니면 (연/월/일)로. 오늘 날짜면 (시/분)으로 표시하도록 구성했습니다.